### PR TITLE
docs: add Nordzy icon theme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,11 @@ emerge --ask www-client/firefox-bin mail-client/thunderbird-bin
 emerge --ask app-shells/zsh app-shells/zsh-autosuggestions app-shells/zsh-syntax-highlighting
 chsh -s /bin/zsh lars
 
+# Nordzy icon theme
+mkdir -p /usr/share/icons
+curl -L https://github.com/MolassesLover/Nordzy-icon/releases/latest/download/Nordzy.tar.gz \
+  | tar -xz -C /usr/share/icons
+
 # Exit and reboot
 exit; umount -R /mnt/gentoo; reboot
 ```


### PR DESCRIPTION
## Summary
- note how to install the Nordzy icon theme

## Testing
- `markdownlint README.md` *(fails: MD013 line-length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d2d41c88330b59e8187a7fb1770