### PR TITLE
Start wallpaper and notification daemons in autostart

### DIFF
--- a/mangowc-config/autostart.sh
+++ b/mangowc-config/autostart.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
-# Start Waybar with the provided configuration
+
+# Update environment for Wayland
 dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP=wlroots
+
+# Set wallpaper
+swaybg -i ~/.config/mango/wallpapers/default.jpg &
+
+# Launch notification daemon
+mako &
+
+# Start Waybar with the provided configuration
 waybar -c ~/.config/mango/waybar/config -s ~/.config/mango/waybar/style.css &


### PR DESCRIPTION
## Summary
- start swaybg for default wallpaper
- launch mako notification daemon
- keep Waybar autostart

## Testing
- `shellcheck mangowc-config/autostart.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bb43b06a148330b47747093ae52b3a