### PR TITLE
Add system metrics modules to Waybar top bar

### DIFF
--- a/mangowc-config/waybar/config
+++ b/mangowc-config/waybar/config
@@ -6,7 +6,23 @@
     "height": 28,
     "modules-left": ["mango/workspaces"],
     "modules-center": ["clock"],
-    "modules-right": ["tray"]
+    "modules-right": ["tray", "cpu", "memory", "network", "backlight"],
+    "cpu": {
+      "format": "{icon} {usage}%",
+      "format-icons": { "default": "\uf2db" }
+    },
+    "memory": {
+      "format": "{icon} {percentage}%",
+      "format-icons": { "default": "\uf538" }
+    },
+    "network": {
+      "format": "{icon} {ifname}",
+      "format-icons": { "default": "\uf1eb" }
+    },
+    "backlight": {
+      "format": "{icon} {percent}%",
+      "format-icons": { "default": "\uf0eb" }
+    }
   },
   {
     "name": "left",

--- a/mangowc-config/waybar/style.css
+++ b/mangowc-config/waybar/style.css
@@ -29,3 +29,10 @@
 #tray {
   padding: 0 4px;
 }
+
+#cpu,
+#memory,
+#network,
+#backlight {
+  padding: 0 8px;
+}


### PR DESCRIPTION
## Summary
- add CPU, memory, network, and backlight modules to top Waybar bar
- style new modules with consistent padding

## Testing
- `jq . mangowc-config/waybar/config | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bb43af4dec8330a88727c906bbfca9