### PR TITLE
Add theme variables to Waybar style sheet

### DIFF
--- a/mangowc-config/waybar/style.css
+++ b/mangowc-config/waybar/style.css
@@ -1,25 +1,35 @@
+/* Theme variables for Waybar.
+   Override these in another stylesheet or later in this file to create a new theme. */
+:root {
+  --color-bg: #2e3440;
+  --color-accent: #3b4252;
+  --color-accent-alt: #434c5e;
+  --color-accent-hover: #4c566a;
+  --color-text: #d8dee9;
+}
+
 * {
   border: none;
   border-radius: 0;
   font-family: monospace;
   font-size: 12px;
-  color: #d8dee9;
+  color: var(--color-text);
 }
 
 #top {
-  background: #2e3440;
+  background: var(--color-bg);
 }
 
 #left {
-  background: #3b4252;
+  background: var(--color-accent);
 }
 
 #left .module {
-  background: #434c5e;
+  background: var(--color-accent-alt);
 }
 
 #left .module:hover {
-  background: #4c566a;
+  background: var(--color-accent-hover);
 }
 
 #clock {
@@ -29,3 +39,4 @@
 #tray {
   padding: 0 4px;
 }
+


### PR DESCRIPTION
## Summary
- define CSS variables for Waybar colors
- document how to override variables for new themes
- use CSS variables instead of hard-coded colors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb43ae9c488330af098f6c9acaf516